### PR TITLE
Enhancing File Reusability by Supporting File Descriptors to Avoid Repeated Open/Close Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ JUring is a high-performance Java library that provides bindings to Linux's io_u
 using Java's Foreign Function & Memory API. Doing Random reads JUring achieves 75,48% better performance than Java NIO FileChannel
 operations for local files and 86.92% better performance for remote files.
 
-## Performance 
+## Performance
 The following benchmarks show the improvement of using io_uring over Java built-in I/O.
 The test ran on a Linux machine with 32 cores, a nvme SSD, and a mounted remote directory.
 
@@ -27,13 +27,13 @@ BenchMarkLibUring.libUringBlocking                    thrpt    5  1.987 ± 0.092
 BenchMarkLibUring.readUsingFileChannel                thrpt    5  1.063 ± 0.637  ops/ms
 BenchMarkLibUring.readUsingFileChannelVirtualThreads  thrpt    5  1.096 ± 0.838  ops/ms
 ```
-The remote machine uses HDD and is connected with a Cat 5E cable to the machine running the benchmarks. The benchmarks were run 
-using a maximum of 5 threads, using more threads opened too many file descriptors. 
+The remote machine uses HDD and is connected with a Cat 5E cable to the machine running the benchmarks. The benchmarks were run
+using a maximum of 5 threads, using more threads opened too many file descriptors.
 
 ## Benchmark Methodology
 The benchmarks are conducted using JMH (Java Microbenchmark Harness) with the following parameters:
 
-- Each test performs 2300 operations per invocation 
+- Each test performs 2300 operations per invocation
 - Tests using local files ran with 32 threads
 - Tests using remote files ran with 5 threads (Linux threw errors when using more threads to run the FileChannel and io_uring example)
 - Queue depth of 2500 for io_uring operations
@@ -66,9 +66,9 @@ Reading from a file
 try (JUringBlocking io = new JUringBlocking(32)) {
     // Read file
     BlockingReadResult result = io.prepareRead("input.txt", 1024, 0);
-    
+
     io.submit();
-    
+
     MemorySegment buffer = result.getBuffer();
     // Process buffer...
     result.freeBuffer();
@@ -77,9 +77,9 @@ try (JUringBlocking io = new JUringBlocking(32)) {
 // Non-blocking API Example
 try (JUring io = new JUring(32)) {
     long id = io.prepareRead("input.txt", 1024, 0);
-    
+
     io.submit();
-    
+
     Result result = io.waitForResult();
     if (result instanceof ReadResult r) {
         MemorySegment buffer = r.getBuffer();
@@ -94,26 +94,34 @@ Write to a file
 // Blocking API Example
 try (JUringBlocking io = new JUringBlocking(32)) {
     byte[] data = "Hello, World!".getBytes();
-    BlockingWriteResult writeResult = io.prepareWrite("output.txt", data, 0);
-    
+    int fd = io.openFile("test.txt");
+    BlockingWriteResult writeResult = io.prepareWrite(fd, data, 0);
+
     io.submit();
-    
+
     long bytesWritten = writeResult.getResult();
     System.out.println("Wrote " + bytesWritten + " bytes");
+
+    // if read/write operation successfully done then close the file descriptors
+    io.closeFile(fd);
 }
 
 // Non-blocking API Example
 try (JUring io = new JUring(32)) {
     byte[] data = "Hello, World!".getBytes();
-    long id = io.prepareWrite("output.txt", data, 0);
-    
+    int fd = iouring.openFile("test.txt");
+    long id = io.prepareWrite(fd, data, 0);
+
     io.submit();
-    
+
     Result result = io.waitForResult();
     if (result instanceof WriteResult w) {
         long bytesWritten = w.getResult();
         System.out.println("Wrote " + bytesWritten + " bytes");
     }
+
+    // if read/write operation successfully done then close the file descriptors
+        io.closeFile(fd);
 }
 ```
 
@@ -146,16 +154,18 @@ Result result = io.waitForResult();
 
 5. **Cleanup**: Free read buffer
 
-For read operations it is necessary to free the buffer that lives inside the result. The buffers are created using malloc and are not managed by an arena. They are MemorySegments, so it is possible to 
+For read operations it is necessary to free the buffer that lives inside the result. The buffers are created using malloc and are not managed by an arena. They are MemorySegments, so it is possible to
 have them cleaned up when an area closes.
 ```java
 result.freeBuffer();
 ```
 Freeing buffers is not necessary for write operations, these buffers are automatically freed when the operation is seen in the completion queue by JUring.
 
+JUring/ JUringBlocking class close() method will close all file descriptors but best practice is to close them manually.
+
 ## Thread Safety
-JURing is not thread safe, from what I read about io_uring there should only be one instance per thread. I want to copy this behaviour to 
-not deviate too much from how io_works. The completion and submission queue used by io_uring don't support multiple threads writing to them at the same time. Preparing operations or waiting 
+JURing is not thread safe, from what I read about io_uring there should only be one instance per thread. I want to copy this behaviour to
+not deviate too much from how io_works. The completion and submission queue used by io_uring don't support multiple threads writing to them at the same time. Preparing operations or waiting
 for completions should be done by a single thread. Processing the results/buffers is thread safe.
 
 ## Current Limitations and Future Improvements
@@ -163,7 +173,7 @@ for completions should be done by a single thread. Processing the results/buffer
 ### Creation cost of JUring instances
 - Creating an instance takes a few of milliseconds, I am working on minimizing this creation time.
 
-### Memory Usage 
+### Memory Usage
 - The current implementation has higher memory usage than ideal. This is a known issue that I'm actively working on improving.
 
 ## Future improvements planned:
@@ -172,7 +182,7 @@ for completions should be done by a single thread. Processing the results/buffer
 - Adding more io_uring features
 - File modes and flags
 - Adding a blocking-api for local files
-- Better memory usage 
-- Improved memory cleanup strategies (smart MemorySegments) 
+- Better memory usage
+- Improved memory cleanup strategies (smart MemorySegments)
 - Encoding support
 - Support for sockets

--- a/src/main/java/com/davidvlijmincx/lio/api/JUringBlocking.java
+++ b/src/main/java/com/davidvlijmincx/lio/api/JUringBlocking.java
@@ -63,18 +63,30 @@ public class JUringBlocking implements AutoCloseable {
         jUring.submit();
     }
 
-    public BlockingReadResult prepareRead(String path, int size, int offset) {
-        long id = jUring.prepareRead(path, size, offset);
+    public BlockingReadResult prepareRead(int fd, int size, int offset) {
+        long id = jUring.prepareRead(fd, size, offset);
         BlockingReadResult result = new BlockingReadResult(id);
         requests.put(id, result);
         return result;
     }
 
-    public BlockingWriteResult prepareWrite(String path, byte[] bytes, int offset) {
-        long id = jUring.prepareWrite(path, bytes, offset);
+    public BlockingWriteResult prepareWrite(int fd, byte[] bytes, int offset) {
+        long id = jUring.prepareWrite(fd, bytes, offset);
         BlockingWriteResult result = new BlockingWriteResult(id);
         requests.put(id, result);
         return result;
+    }
+
+    public int openFile(String path) {
+        return jUring.openFile(path);
+    }
+
+    public int openFile(String path, int flags, int mode) {
+        return jUring.openFile(path,flags,mode);
+    }
+
+    public void closeFile(int fd) {
+        jUring.closeFile(fd);
     }
 
     public void freeReadBuffer(MemorySegment buffer) {

--- a/src/test/java/bench/BenchMarkLibUring.java
+++ b/src/test/java/bench/BenchMarkLibUring.java
@@ -46,11 +46,13 @@ public class BenchMarkLibUring {
         try(ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
 
             for (int i = 0; i < paths.length; i++) {
-                BlockingReadResult r = q.prepareRead(paths[i].sPath(), paths[i].bufferSize(), paths[i].offset());
+                int fd = q.openFile(paths[i].sPath());
+                BlockingReadResult r = q.prepareRead(fd, paths[i].bufferSize(), paths[i].offset());
                 q.submit();
                 executor.execute(() -> {
                     blackhole.consume(r.getBuffer());
                     r.freeBuffer();
+                    q.closeFile(fd);
                 });
             }
         }
@@ -66,7 +68,8 @@ public class BenchMarkLibUring {
         try {
             int j = 0;
             for (var path : paths) {
-                q.prepareRead(path.sPath(), path.bufferSize(), path.offset());
+                int fd = q.openFile(path.sPath());
+                q.prepareRead(fd, path.bufferSize(), path.offset());
 
                 j++;
                 if (j % 100 == 0) {

--- a/src/test/java/com/davidvlijmincx/lio/api/JUringBlockingTest.java
+++ b/src/test/java/com/davidvlijmincx/lio/api/JUringBlockingTest.java
@@ -27,7 +27,8 @@ class JUringBlockingTest {
 
     @Test
     void readFromFile() {
-        BlockingReadResult result = jUringBlocking.prepareRead("src/test/resources/read_file", 14, 0);
+        int fd = jUringBlocking.openFile("src/test/resources/read_file");
+        BlockingReadResult result = jUringBlocking.prepareRead(fd, 14, 0);
 
         jUringBlocking.submit();
 
@@ -37,13 +38,15 @@ class JUringBlockingTest {
         String string = result.getBuffer().getString(0);
         result.freeBuffer();
         assertEquals("Hello, World!", string);
+        jUringBlocking.closeFile(fd);
     }
 
     @Test
     void multiReadFromFile() {
-        BlockingReadResult result = jUringBlocking.prepareRead("src/test/resources/read_file", 14, 0);
-        BlockingReadResult result1 = jUringBlocking.prepareRead("src/test/resources/read_file", 5, 0);
-        BlockingReadResult result2 = jUringBlocking.prepareRead("src/test/resources/read_file", 7, 7);
+        int fd = jUringBlocking.openFile("src/test/resources/read_file");
+        BlockingReadResult result = jUringBlocking.prepareRead(fd, 14, 0);
+        BlockingReadResult result1 = jUringBlocking.prepareRead(fd, 5, 0);
+        BlockingReadResult result2 = jUringBlocking.prepareRead(fd, 7, 7);
 
         jUringBlocking.submit();
 
@@ -59,17 +62,21 @@ class JUringBlockingTest {
         result.freeBuffer();
         result1.freeBuffer();
         result2.freeBuffer();
+
+        jUringBlocking.closeFile(fd);
     }
 
     @Test
     void readFromFileAtOffset() {
-        BlockingReadResult result = jUringBlocking.prepareRead("src/test/resources/read_file", 6, 7);
+        int fd = jUringBlocking.openFile("src/test/resources/read_file");
+        BlockingReadResult result = jUringBlocking.prepareRead(fd, 6, 7);
 
         jUringBlocking.submit();
 
         String string = result.getBuffer().getString(0);
         result.freeBuffer();
         assertEquals("World!", string);
+        jUringBlocking.closeFile(fd);
     }
 
     @Test
@@ -80,7 +87,9 @@ class JUringBlockingTest {
         String input = "Hello, from Java";
         var inputBytes = input.getBytes();
 
-        BlockingWriteResult result = jUringBlocking.prepareWrite(path.toString(), inputBytes, 0);
+        int fd = jUringBlocking.openFile(path.toString());
+
+        BlockingWriteResult result = jUringBlocking.prepareWrite(fd, inputBytes, 0);
 
         jUringBlocking.submit();
 
@@ -88,6 +97,8 @@ class JUringBlockingTest {
 
         String writtenContent = Files.readString(path);
         assertEquals(input, writtenContent);
+
+        jUringBlocking.closeFile(fd);
     }
 
     @Test
@@ -98,7 +109,9 @@ class JUringBlockingTest {
         String input = "hello, from Java";
         var inputBytes = input.getBytes();
 
-        BlockingWriteResult result = jUringBlocking.prepareWrite(path.toString(), inputBytes, 4);
+        int fd = jUringBlocking.openFile(path.toString());
+
+        BlockingWriteResult result = jUringBlocking.prepareWrite(fd, inputBytes, 4);
 
         jUringBlocking.submit();
 
@@ -107,6 +120,7 @@ class JUringBlockingTest {
         String writtenContent = Files.readString(path);
         assertEquals("Big hello, from Java", writtenContent);
 
+        jUringBlocking.closeFile(fd);
     }
 
     @Test
@@ -117,11 +131,14 @@ class JUringBlockingTest {
         String input = "hello, from Java";
         var inputBytes = input.getBytes();
 
-        BlockingReadResult readResult = jUringBlocking.prepareRead(readPath.toString(), 14, 0);
-        BlockingWriteResult writeResult = jUringBlocking.prepareWrite(writePath.toString(), inputBytes, 4);
-        BlockingReadResult readResult1 = jUringBlocking.prepareRead(readPath.toString(), 5, 0);
-        BlockingWriteResult writeResult1 = jUringBlocking.prepareWrite(writePath.toString(), inputBytes, 4);
-        BlockingReadResult readResult2 = jUringBlocking.prepareRead(readPath.toString(), 7, 7);
+        int fd = jUringBlocking.openFile(readPath.toString());
+        int writeFd = jUringBlocking.openFile(writePath.toString());
+
+        BlockingReadResult readResult = jUringBlocking.prepareRead(fd, 14, 0);
+        BlockingWriteResult writeResult = jUringBlocking.prepareWrite(writeFd, inputBytes, 4);
+        BlockingReadResult readResult1 = jUringBlocking.prepareRead(fd, 5, 0);
+        BlockingWriteResult writeResult1 = jUringBlocking.prepareWrite(writeFd, inputBytes, 4);
+        BlockingReadResult readResult2 = jUringBlocking.prepareRead(fd, 7, 7);
 
         jUringBlocking.submit();
 


### PR DESCRIPTION
This approach aims to improve file handling efficiency by utilizing file descriptors, which allow a file to remain open for continuous read/write operations. By doing so, it eliminates the need for repeatedly opening and closing the file, thereby reducing overhead and improving performance, especially in scenarios involving frequent file interactions. This method enhances the reusability of files and optimizes system resource usage.

Changes done in classes :

Juring
JuringBlocking

Change logs :

- added set to maintain file descriptors.
- Users have the option to manually close a file descriptor using the closeFile(fd) method.
- If the file descriptor is not closed manually, all file descriptors will be automatically closed when the close() method of Juring or JuringBlocking is called.